### PR TITLE
Fix bower main to point to lib version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "select",
-  "main": "select.js",
+  "main": "js/select.js",
   "version": "0.5.2",
   "homepage": "https://github.com/HubSpot/select",
   "authors": [


### PR DESCRIPTION
The `main` key in `bower.json` should not point to the distribution version of select.js that includes dependencies (tether) compiled in.

Many asset-pipeline setups directly include the `main` file, so listing _tether_ as a dependency along side this would cause redundant code to be included.

I've noticed this issue with all of the tether-based projects and can make a PR on each if this is merged.
