### PR TITLE
Fix #55: Use click event for all devices

### DIFF
--- a/src/css/select-theme-chosen.sass
+++ b/src/css/select-theme-chosen.sass
@@ -92,6 +92,7 @@ $mobileBreakPointSize: ($maxRows + 4) * $optionHeight
     +inline-block
     +user-select(none)
     +no-mobile-tap-highlight
+    touch-action: manipulation;
     border-radius: 5px
     box-shadow: 0 0 3px #FFF inset, 0 1px 1px rgba(0, 0, 0, 0.1)
     background-image: linear-gradient(to bottom, #ffffff 20%, #f6f6f6 50%, #eeeeee 52%, #f4f4f4 100%)

--- a/src/css/select-theme-dark.sass
+++ b/src/css/select-theme-dark.sass
@@ -90,6 +90,7 @@ $mobileBreakPointSize: ($maxRows + 4) * $optionHeight
     +inline-block
     +user-select(none)
     +no-mobile-tap-highlight
+    touch-action: manipulation;
     border-radius: .25em
     position: relative
     padding: $paddingTopBottom 3em $paddingTopBottom 1em

--- a/src/css/select-theme-default.sass
+++ b/src/css/select-theme-default.sass
@@ -90,6 +90,7 @@ $mobileBreakPointSize: ($maxRows + 4) * $optionHeight
     +inline-block
     +user-select(none)
     +no-mobile-tap-highlight
+    touch-action: manipulation;
     border-radius: .25em
     position: relative
     padding: $paddingTopBottom 3em $paddingTopBottom 1em

--- a/src/js/select.js
+++ b/src/js/select.js
@@ -15,9 +15,6 @@ const SPACE = 32;
 const UP = 38;
 const DOWN = 40;
 
-const touchDevice = 'ontouchstart' in document.documentElement;
-const clickEvent = touchDevice ? 'touchstart' : 'click';
-
 function useNative() {
   const {innerWidth, innerHeight} = window;
   return touchDevice && (innerWidth <= 640 || innerHeight <= 640);
@@ -303,12 +300,12 @@ class Select extends Evented {
   }
 
   bindClick() {
-    this.target.addEventListener(clickEvent, (e) => {
+    this.target.addEventListener('click', (e) => {
       e.preventDefault();
       this.toggle();
     });
 
-    document.addEventListener(clickEvent, (event) => {
+    document.addEventListener('click', (event) => {
       if (!this.isOpen()) {
         return;
       }


### PR DESCRIPTION
There's no need to use the touch event instead of click on touch devices to save on performance if we set `touch-action: manipulation;` following the suggestion here: https://developers.google.com/web/updates/2013/12/300ms-tap-delay-gone-away